### PR TITLE
Improve Ki67 detection accuracy

### DIFF
--- a/ki67-analyzer-standalone.html
+++ b/ki67-analyzer-standalone.html
@@ -410,13 +410,13 @@ canvas {
                         </label>
                         <label>
                             Merge Distance:
-                            <input type="range" id="mergeDistance" min="5" max="30" value="15">
-                            <span id="mergeDistanceValue">15</span>
+                            <input type="range" id="mergeDistance" min="5" max="30" value="10">
+                            <span id="mergeDistanceValue">10</span>
                         </label>
                         <label>
                             IoU Threshold:
-                            <input type="range" id="iouThreshold" min="0.1" max="0.8" step="0.05" value="0.3">
-                            <span id="iouThresholdValue">0.3</span>
+                            <input type="range" id="iouThreshold" min="0.1" max="0.8" step="0.05" value="0.2">
+                            <span id="iouThresholdValue">0.2</span>
                         </label>
                         
                         <div class="param-controls">
@@ -491,11 +491,9 @@ async function processImageChunk(data) {
     const { imageData, threshold, minSize, maxSize, chunkInfo, params } = data;
     
     const mat = cv.matFromImageData(imageData);
-    const gray = new cv.Mat();
-    
-    cv.cvtColor(mat, gray, cv.COLOR_RGBA2GRAY);
-    
-    // CLAHE for contrast enhancement
+    const gray = extractDAB(mat);
+    cv.medianBlur(gray, gray, 3);
+
     const clipLimit = params.claheClipLimit || 2.0;
     const tileSize = params.claheTileSize || 8;
     const clahe = new cv.CLAHE(clipLimit, new cv.Size(tileSize, tileSize));
@@ -535,14 +533,36 @@ async function processImageChunk(data) {
     binary4.delete();
     
     // Merge and deduplicate results
-    const mergedNuclei = mergeNuclei(allNuclei, params.mergeDistance || 15, params.iouThreshold || 0.3);
+    const mergedNuclei = mergeNuclei(allNuclei, params.mergeDistance || 10, params.iouThreshold || 0.2);
     
     mat.delete();
     gray.delete();
     enhanced.delete();
     clahe.delete();
-    
+
     return mergedNuclei;
+}
+
+function extractDAB(srcRGBMat) {
+    let od = new cv.Mat();
+    srcRGBMat.convertTo(od, cv.CV_32F, 1 / 255.0);
+    cv.add(od, new cv.Scalar(1.0, 1.0, 1.0), od);
+    cv.log(od, od);
+    cv.multiply(od, new cv.Scalar(-1.0, -1.0, -1.0), od);
+
+    const dab = new cv.Mat();
+    const kernel = cv.matFromArray(1, 3, cv.CV_32F, [0.650, 0.704, 0.286]);
+    cv.transform(od, dab, kernel);
+
+    let dab8 = new cv.Mat();
+    cv.normalize(dab, dab8, 0, 255, cv.NORM_MINMAX);
+    dab8.convertTo(dab8, cv.CV_8U);
+
+    od.delete();
+    dab.delete();
+    kernel.delete();
+
+    return dab8;
 }
 
 function findContoursInBinary(binary, grayImage, minSize, maxSize, threshold, chunkInfo, params) {
@@ -567,28 +587,28 @@ function findContoursInBinary(binary, grayImage, minSize, maxSize, threshold, ch
             const cy = moments.m01 / moments.m00;
             const rect = cv.boundingRect(contour);
             
-            // Ensure ROI is within bounds
-            if (rect.x + rect.width <= grayImage.cols && rect.y + rect.height <= grayImage.rows) {
-                const roiGray = grayImage.roi(rect);
-                const meanIntensity = cv.mean(roiGray)[0];
-                
-                // Improved classification logic
-                const positiveFactor = params.positiveFactor || 0.8;
-                const isPositive = meanIntensity < threshold * positiveFactor;
-                
-                nuclei.push({
-                    id: Date.now() + Math.random(),
-                    x: cx + chunkInfo.offsetX,
-                    y: cy + chunkInfo.offsetY,
-                    width: rect.width,
-                    height: rect.height,
-                    area: area,
-                    intensity: meanIntensity,
-                    isPositive: isPositive
-                });
-                
-                roiGray.delete();
-            }
+            const mask = new cv.Mat.zeros(grayImage.rows, grayImage.cols, cv.CV_8UC1);
+            const cVec = new cv.MatVector();
+            cVec.push_back(contour);
+            cv.drawContours(mask, cVec, 0, new cv.Scalar(255), -1);
+            const meanIntensity = cv.mean(grayImage, mask)[0];
+
+            const positiveFactor = params.positiveFactor || 0.8;
+            const isPositive = meanIntensity < threshold * positiveFactor;
+
+            nuclei.push({
+                id: Date.now() + Math.random(),
+                x: cx + chunkInfo.offsetX,
+                y: cy + chunkInfo.offsetY,
+                width: rect.width,
+                height: rect.height,
+                area: area,
+                intensity: meanIntensity,
+                isPositive: isPositive
+            });
+
+            cVec.delete();
+            mask.delete();
         }
         contour.delete();
     }
@@ -1002,21 +1022,17 @@ class Ki67Analyzer {
     async processImageLocal() {
         const src = cv.imread(this.imageCanvas);
         const gray = new cv.Mat();
-        const binary = new cv.Mat();
         
         try {
-            // DAB 抽出処理を追加
+            // DAB 抽出処理
             const dabImg = this.extractDAB(src);
-            cv.cvtColor(dabImg, gray, cv.COLOR_GRAY2RGB);
-            dabImg.delete();
-
+            // ノイズ除去
+            cv.medianBlur(dabImg, dabImg, 3);
             // CLAHE 処理
-            const clahe = new cv.CLAHE(parseFloat(this.claheClipLimitSlider.value), 
+            const clahe = new cv.CLAHE(parseFloat(this.claheClipLimitSlider.value),
                 new cv.Size(parseInt(this.claheTileSizeSlider.value), parseInt(this.claheTileSizeSlider.value)));
-            clahe.apply(gray, gray);
-
-            // 以降の処理は既存のまま
-            cv.cvtColor(gray, binary, cv.COLOR_RGB2GRAY);
+            clahe.apply(dabImg, gray);
+            dabImg.delete();
 
             const threshold = parseInt(this.thresholdSlider.value);
             const minSize = parseInt(this.minSizeSlider.value);
@@ -1067,7 +1083,6 @@ class Ki67Analyzer {
             
             src.delete();
             gray.delete();
-            binary.delete();
         } catch (error) {
             console.error('Local processing failed:', error);
             alert('Local processing failed: ' + error.message);
@@ -1428,28 +1443,28 @@ class Ki67Analyzer {
                 const cy = moments.m01 / moments.m00;
                 const rect = cv.boundingRect(contour);
                 
-                // Ensure ROI is within bounds
-                if (rect.x + rect.width <= grayImage.cols && rect.y + rect.height <= grayImage.rows) {
-                    const roiGray = grayImage.roi(rect);
-                    const meanIntensity = cv.mean(roiGray)[0];
-                    
-                    // Improved classification logic
-                    const positiveFactor = parseFloat(this.positiveFactorSlider.value);
-                    const isPositive = meanIntensity < threshold * positiveFactor;
-                    
-                    nuclei.push({
-                        id: Date.now() + Math.random(),
-                        x: cx,
-                        y: cy,
-                        width: rect.width,
-                        height: rect.height,
-                        area: area,
-                        intensity: meanIntensity,
-                        isPositive: isPositive
-                    });
-                    
-                    roiGray.delete();
-                }
+                const mask = new cv.Mat.zeros(grayImage.rows, grayImage.cols, cv.CV_8UC1);
+                const cVec = new cv.MatVector();
+                cVec.push_back(contour);
+                cv.drawContours(mask, cVec, 0, new cv.Scalar(255), -1);
+                const meanIntensity = cv.mean(grayImage, mask)[0];
+
+                const positiveFactor = parseFloat(this.positiveFactorSlider.value);
+                const isPositive = meanIntensity < threshold * positiveFactor;
+
+                nuclei.push({
+                    id: Date.now() + Math.random(),
+                    x: cx,
+                    y: cy,
+                    width: rect.width,
+                    height: rect.height,
+                    area: area,
+                    intensity: meanIntensity,
+                    isPositive: isPositive
+                });
+
+                cVec.delete();
+                mask.delete();
             }
             contour.delete();
         }


### PR DESCRIPTION
## Summary
- refine merge heuristics defaults
- fix local DAB processing and add median blur
- compute intensity within contour mask
- use DAB extraction in worker

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_683fde14c7d4832bb1186f3492f79689